### PR TITLE
updated preorder serializer

### DIFF
--- a/market_next_door_api/market_next_door_api/models.py
+++ b/market_next_door_api/market_next_door_api/models.py
@@ -56,7 +56,9 @@ class Market(models.Model):
 
 class Preorder(models.Model):
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE, null=False)
+    vendor = models.ForeignKey(Vendor, on_delete=models.CASCADE, null=False)
     item = models.ManyToManyField(Item, through='PreorderItem')
+    quantity = models.IntegerField(default=1)
     ready = models.BooleanField(default=False)
     date_created = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/market_next_door_api/market_next_door_api/serializers.py
+++ b/market_next_door_api/market_next_door_api/serializers.py
@@ -40,17 +40,4 @@ class VendorSerializer(serializers.ModelSerializer):
 class PreorderSerializer(serializers.ModelSerializer):
   class Meta:
     model = Preorder
-    fields = ['id', 'customer', 'item', 'ready']
-  
-  def to_representation(self, instance):
-    representation = super().to_representation(instance)
-    data = {
-      "id": representation['id'],
-      "type": "preorder",
-      "attributes": {
-        "customer": representation['customer'],
-        "item": representation['item'],
-        "ready": representation['ready']
-      }
-    }
-    return data
+    fields = ['id', 'customer', 'vendor', 'item', 'quantity', 'date_created','updated_at','ready']


### PR DESCRIPTION
## Implements/Fixes: title-here
Updates the JSON returns for Preorder to include id, customer, vendor, date_created, updated_at, item, quantity, and ready fields. I updated the models to to get the foreign keys for customer and vendos  

## This closes issue:
 (add issue number here)
nothing this is an update

## Neccesary checkmarks:
- [ ] All Tests are Passing
- [x ] The code will run locally


## Type of change
- [ ] New feature
- [ x] Bug Fix


## Check the correct boxes
- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything


## Testing Changes
- [x ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)


## Checklist:
- [ x] My code has no unused/commented out code
- [ x] I have reviewed my code
- [  ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code


TY!